### PR TITLE
feat: add rich text custom component

### DIFF
--- a/RichText.vue
+++ b/RichText.vue
@@ -24,7 +24,9 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, watch } from 'vue'
+
+defineOptions({ name: 'RichText' })
 import { Editor, EditorContent, BubbleMenu } from '@tiptap/vue-3'
 import StarterKit from '@tiptap/starter-kit'
 import CommentExtension from '@sereneinserenade/tiptap-comment-extension'
@@ -35,10 +37,10 @@ const props = defineProps({
   supabaseUrl: { type: String, required: true },
   supabaseKey: { type: String, required: true },
   documentId: { type: String, required: true },
-  initialContent: { type: Object, default: () => ({}) }
+  modelValue: { type: Object, default: () => ({}) }
 })
 
-const emit = defineEmits(['update:content'])
+const emit = defineEmits(['update:modelValue'])
 
 const supabase = createClient(props.supabaseUrl, props.supabaseKey)
 
@@ -63,11 +65,21 @@ const editor = new Editor({
       }
     })
   ],
-  content: props.initialContent,
+  content: props.modelValue,
   onUpdate: () => {
-    emit('update:content', editor.getJSON())
+    emit('update:modelValue', editor.getJSON())
   }
 })
+
+watch(
+  () => props.modelValue,
+  newContent => {
+    const current = editor.getJSON()
+    if (JSON.stringify(newContent) !== JSON.stringify(current)) {
+      editor.commands.setContent(newContent)
+    }
+  }
+)
 
 onMounted(async () => {
   const { data, error } = await supabase

--- a/ww-config.js
+++ b/ww-config.js
@@ -1,0 +1,38 @@
+export default {
+  editor: {
+    label: {
+      en: 'Rich Text',
+    },
+    icon: 'file-text',
+  },
+  properties: {
+    supabaseUrl: {
+      label: {
+        en: 'Supabase URL',
+      },
+      type: 'Text',
+      bindable: true,
+    },
+    supabaseKey: {
+      label: {
+        en: 'Supabase Key',
+      },
+      type: 'Text',
+      bindable: true,
+    },
+    documentId: {
+      label: {
+        en: 'Document ID',
+      },
+      type: 'Text',
+      bindable: true,
+    },
+    modelValue: {
+      label: {
+        en: 'Content',
+      },
+      type: 'Object',
+      bindable: true,
+    },
+  },
+}


### PR DESCRIPTION
## Summary
- convert rich text module into Vue component usable as a WeWeb custom component
- expose content via v-model and synchronize with editor updates
- provide WeWeb configuration for editor properties

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/weweb/package.json')*


------
https://chatgpt.com/codex/tasks/task_b_6895a3a1aea483298d8679ea2549a017